### PR TITLE
Show a god for each color

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,10 @@
                 <button id="mixButton" disabled>混色実験開始！</button>
             </section>
 
+            <section class="god-display" id="godDisplay" style="display: none;">
+                <h2 id="godName"></h2>
+            </section>
+
             <section class="result-area" id="resultArea" style="display: none;">
                 <h2>新しい精霊が生まれました！</h2>
                 <div class="new-spirit">

--- a/script.js
+++ b/script.js
@@ -97,6 +97,7 @@ function addSelectedColor(spirit) {
     if (gameState.selectedColors.length < 2) {
         gameState.selectedColors.push(spirit);
         updateMixingSlots();
+        displayGod(spirit);
 
         if (gameState.selectedColors.length === 2) {
             document.getElementById('mixButton').disabled = false;
@@ -177,6 +178,7 @@ function setupDropZones() {
 
                     gameState.selectedColors[index] = spirit;
                     updateMixingSlots();
+                    displayGod(spirit);
                 }
             }
         });
@@ -241,8 +243,18 @@ function showMixResult(spirit) {
     spiritNameInput.value = ''; // 入力欄をクリア
     spiritNameInput.placeholder = '新しい名前を入力してね！'; // プレースホルダーを設定
 
+    displayGod(spirit);
     resultArea.style.display = 'block';
     resultArea.scrollIntoView({ behavior: 'smooth' });
+}
+
+function displayGod(spirit) {
+    const godDisplay = document.getElementById('godDisplay');
+    const godName = document.getElementById('godName');
+    if (godDisplay && godName) {
+        godName.textContent = `${spirit.name}の神様が現れた！`;
+        godDisplay.style.display = 'block';
+    }
 }
 
 function nameNewSpirit() {
@@ -336,6 +348,7 @@ function resetMixingArea() {
     resultArea.style.display = 'none';
 
     document.getElementById('mixButton').disabled = true;
+    document.getElementById('godDisplay').style.display = 'none';
 }
 
 // デバッグ用：コンソールでゲーム状態確認

--- a/style.css
+++ b/style.css
@@ -194,6 +194,15 @@ section h2 {
     box-shadow: none;
 }
 
+/* 神様表示エリア */
+.god-display {
+    text-align: center;
+    font-size: 1.2rem;
+    color: #8e44ad;
+    margin-bottom: 20px;
+    animation: fadeIn 0.8s ease-out;
+}
+
 /* 結果表示エリア */
 .result-area {
     text-align: center;


### PR DESCRIPTION
## Summary
- Display each color's god when selected or mixed
- Add dedicated section and styles for color gods

## Testing
- `npm test` (fails: enoent could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6897f3ea52d08330b47672c0e37a4501